### PR TITLE
Replace unified diff patch tool with SimpleEditSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The app runs in a `tokio::main` loop, processing terminal events and app events 
 - **Hot Reload**: Use `cargo watch -x run` for dev.
 
 ## Limitations & Roadmap
-- **Patch Tool**: Basic unified diff parser; needs robust hunk application.
+- **Patch Tool**: Simple edit spec (set_file/replace/insert/delete/rename) with dry-run simulation and fail-fast validation.
 - **Streaming Responses**: Deltas accumulate; implement true streaming.
 - **Headless Mode**: CLI currently launches TUI; add non-interactive mode.
 - **More Agents**: Support local models (e.g., via Ollama).

--- a/core/src/tools/executors/fs/simple_edit.rs
+++ b/core/src/tools/executors/fs/simple_edit.rs
@@ -1,0 +1,368 @@
+use crate::tools::types::SimpleEditOp;
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::ErrorKind;
+use std::path::Path;
+
+pub(crate) struct PlannedFile {
+    original: Option<String>,
+    current: Option<String>,
+}
+
+impl PlannedFile {
+    fn existing(content: String) -> Self {
+        Self { original: Some(content.clone()), current: Some(content) }
+    }
+
+    fn new_missing() -> Self {
+        Self { original: None, current: None }
+    }
+}
+
+pub(crate) struct SimpleEditPlanner {
+    dry_run: bool,
+    files: BTreeMap<String, PlannedFile>,
+    renames: Vec<(String, String, bool)>,
+    created: BTreeSet<String>,
+    modified: BTreeSet<String>,
+    deleted: BTreeSet<String>,
+    descriptions: Vec<String>,
+    bytes_added: u64,
+    bytes_removed: u64,
+}
+
+impl SimpleEditPlanner {
+    pub(crate) fn new(dry_run: bool) -> Self {
+        Self {
+            dry_run,
+            files: BTreeMap::new(),
+            renames: Vec::new(),
+            created: BTreeSet::new(),
+            modified: BTreeSet::new(),
+            deleted: BTreeSet::new(),
+            descriptions: Vec::new(),
+            bytes_added: 0,
+            bytes_removed: 0,
+        }
+    }
+
+    pub(crate) async fn apply_op(&mut self, op: &SimpleEditOp) -> Result<(), String> {
+        match op {
+            SimpleEditOp::SetFile { path, contents } => {
+                self.ensure_entry_allow_new(path).await?;
+                let normalized = normalize_newlines(contents);
+                self.set_current(path, normalized)?;
+                self.descriptions.push(format!("set_file {}", path));
+            }
+            SimpleEditOp::ReplaceOnce { path, find, replace } => {
+                self.ensure_entry(path).await?;
+                let current = self.current_string(path)?;
+                let needle = normalize_newlines(find);
+                let replacement = normalize_newlines(replace);
+                let idx = exactly_once(&current, &needle)?;
+                let mut new_content = current.clone();
+                new_content.replace_range(idx..idx + needle.len(), &replacement);
+                self.set_current(path, new_content)?;
+                self.descriptions.push(format!("replace_once {}", path));
+            }
+            SimpleEditOp::InsertBefore { path, anchor, insert } => {
+                self.ensure_entry(path).await?;
+                let current = self.current_string(path)?;
+                let anchor_text = normalize_newlines(anchor);
+                let insertion = normalize_newlines(insert);
+                let idx = exactly_once(&current, &anchor_text)?;
+                let mut new_content = current.clone();
+                new_content.insert_str(idx, &insertion);
+                self.set_current(path, new_content)?;
+                self.descriptions.push(format!("insert_before {}", path));
+            }
+            SimpleEditOp::InsertAfter { path, anchor, insert } => {
+                self.ensure_entry(path).await?;
+                let current = self.current_string(path)?;
+                let anchor_text = normalize_newlines(anchor);
+                let insertion = normalize_newlines(insert);
+                let idx = exactly_once(&current, &anchor_text)?;
+                let mut new_content = current.clone();
+                new_content.insert_str(idx + anchor_text.len(), &insertion);
+                self.set_current(path, new_content)?;
+                self.descriptions.push(format!("insert_after {}", path));
+            }
+            SimpleEditOp::DeleteFile { path } => {
+                self.ensure_entry(path).await?;
+                self.delete_current(path)?;
+                self.descriptions.push(format!("delete_file {}", path));
+            }
+            SimpleEditOp::RenameFile { path, to } => {
+                if path == to {
+                    return Err("Source and destination paths are the same".to_string());
+                }
+                self.ensure_entry(path).await?;
+                if self.files.get(path).and_then(|e| e.current.as_ref()).is_none() {
+                    return Err(format!("File not found: {}", path));
+                }
+                if let Some(existing) = self.files.get(to) {
+                    if existing.current.is_some() {
+                        return Err(format!("Target already exists: {}", to));
+                    }
+                    self.files.remove(to);
+                    self.created.remove(to);
+                    self.modified.remove(to);
+                    self.deleted.remove(to);
+                } else if path_exists_on_disk(to).await? {
+                    return Err(format!("Target already exists: {}", to));
+                }
+
+                let entry = self.files.remove(path).ok_or_else(|| format!("File state missing: {}", path))?;
+                if entry.current.is_none() {
+                    return Err(format!("File not found: {}", path));
+                }
+                let should_rename = entry.original.is_some();
+                let to_owned = to.to_string();
+                self.files.insert(to_owned.clone(), entry);
+                self.reassign_path(path, &to_owned);
+                self.renames.push((path.to_string(), to_owned.clone(), should_rename));
+                self.descriptions.push(format!("rename_file {} -> {}", path, to));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn finish(self) -> Result<String, String> {
+        if !self.dry_run {
+            self.commit().await?;
+        }
+        Ok(self.build_summary())
+    }
+
+    async fn ensure_entry(&mut self, path: &str) -> Result<(), String> {
+        if self.files.contains_key(path) {
+            return Ok(());
+        }
+        if let Some(content) = read_file_normalized(path).await? {
+            self.files.insert(path.to_string(), PlannedFile::existing(content));
+            Ok(())
+        } else {
+            Err(format!("File not found: {}", path))
+        }
+    }
+
+    async fn ensure_entry_allow_new(&mut self, path: &str) -> Result<(), String> {
+        if self.files.contains_key(path) {
+            return Ok(());
+        }
+        if let Some(content) = read_file_normalized(path).await? {
+            self.files.insert(path.to_string(), PlannedFile::existing(content));
+        } else {
+            self.files.insert(path.to_string(), PlannedFile::new_missing());
+        }
+        Ok(())
+    }
+
+    fn current_string(&self, path: &str) -> Result<String, String> {
+        let entry = self.files.get(path).ok_or_else(|| format!("File state missing: {}", path))?;
+        if let Some(current) = &entry.current {
+            Ok(current.clone())
+        } else {
+            Err(format!("File has been deleted: {}", path))
+        }
+    }
+
+    fn set_current(&mut self, path: &str, new_content: String) -> Result<(), String> {
+        let (prev_len, original_is_none) = {
+            let entry = self.files.get_mut(path).ok_or_else(|| format!("File state missing: {}", path))?;
+            let prev_len = entry.current.as_ref().map(|s| s.len()).unwrap_or(0) as i64;
+            entry.current = Some(new_content);
+            (prev_len, entry.original.is_none())
+        };
+        let new_len = self
+            .files
+            .get(path)
+            .and_then(|entry| entry.current.as_ref())
+            .map(|s| s.len())
+            .unwrap_or(0) as i64;
+        self.record_delta(new_len - prev_len);
+        if original_is_none {
+            self.mark_created(path);
+        } else {
+            self.mark_modified(path);
+        }
+        Ok(())
+    }
+
+    fn delete_current(&mut self, path: &str) -> Result<(), String> {
+        let (prev_len, original_is_some) = {
+            let entry = self.files.get_mut(path).ok_or_else(|| format!("File state missing: {}", path))?;
+            if entry.current.is_none() {
+                return Err(format!("File already deleted: {}", path));
+            }
+            let prev_len = entry.current.as_ref().map(|s| s.len()).unwrap_or(0) as i64;
+            entry.current = None;
+            (prev_len, entry.original.is_some())
+        };
+        self.record_delta(-prev_len);
+        if original_is_some {
+            self.mark_deleted(path);
+        } else {
+            self.created.remove(path);
+            self.modified.remove(path);
+        }
+        Ok(())
+    }
+
+    fn mark_created(&mut self, path: &str) {
+        self.created.insert(path.to_string());
+        self.modified.remove(path);
+        self.deleted.remove(path);
+    }
+
+    fn mark_modified(&mut self, path: &str) {
+        if !self.created.contains(path) {
+            self.modified.insert(path.to_string());
+        }
+        self.deleted.remove(path);
+    }
+
+    fn mark_deleted(&mut self, path: &str) {
+        self.created.remove(path);
+        self.modified.remove(path);
+        self.deleted.insert(path.to_string());
+    }
+
+    fn reassign_path(&mut self, from: &str, to: &str) {
+        if self.created.remove(from) {
+            self.created.insert(to.to_string());
+        }
+        if self.modified.remove(from) {
+            self.modified.insert(to.to_string());
+        }
+        if self.deleted.remove(from) {
+            self.deleted.insert(to.to_string());
+        }
+    }
+
+    fn record_delta(&mut self, delta: i64) {
+        if delta > 0 {
+            self.bytes_added += delta as u64;
+        } else if delta < 0 {
+            self.bytes_removed += (-delta) as u64;
+        }
+    }
+
+    async fn commit(&self) -> Result<(), String> {
+        for (from, to, should_rename) in &self.renames {
+            if !should_rename || from == to {
+                continue;
+            }
+            if let Some(parent) = Path::new(to).parent() {
+                if !parent.as_os_str().is_empty() {
+                    tokio::fs::create_dir_all(parent)
+                        .await
+                        .map_err(|e| format!("Failed to create parent directories for {}: {}", to, e))?;
+                }
+            }
+            tokio::fs::rename(from, to)
+                .await
+                .map_err(|e| format!("Failed to rename {} to {}: {}", from, to, e))?;
+        }
+
+        for (path, entry) in &self.files {
+            match &entry.current {
+                Some(content) => {
+                    if entry.original.is_none() || entry.original.as_ref() != entry.current.as_ref() {
+                        if let Some(parent) = Path::new(path).parent() {
+                            if !parent.as_os_str().is_empty() {
+                                tokio::fs::create_dir_all(parent)
+                                    .await
+                                    .map_err(|e| format!("Failed to create parent directories for {}: {}", path, e))?;
+                            }
+                        }
+                        tokio::fs::write(path, content)
+                            .await
+                            .map_err(|e| format!("Failed to write file {}: {}", path, e))?;
+                    }
+                }
+                None => {
+                    if entry.original.is_some() {
+                        match tokio::fs::remove_file(path).await {
+                            Ok(_) => {}
+                            Err(e) if e.kind() == ErrorKind::NotFound => {}
+                            Err(e) => return Err(format!("Failed to delete file {}: {}", path, e)),
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn build_summary(&self) -> String {
+        let mut lines = Vec::new();
+        if self.dry_run {
+            lines.push("Dry run: no changes were written.".to_string());
+        } else {
+            lines.push("Edits applied successfully.".to_string());
+        }
+
+        if !self.created.is_empty() {
+            lines.push(format!("Created files: {}", self.created.iter().cloned().collect::<Vec<_>>().join(", ")));
+        }
+        if !self.modified.is_empty() {
+            lines.push(format!("Modified files: {}", self.modified.iter().cloned().collect::<Vec<_>>().join(", ")));
+        }
+        if !self.deleted.is_empty() {
+            lines.push(format!("Deleted files: {}", self.deleted.iter().cloned().collect::<Vec<_>>().join(", ")));
+        }
+        if !self.renames.is_empty() {
+            lines.push("Renamed files:".to_string());
+            for (from, to, _) in &self.renames {
+                lines.push(format!("  {} -> {}", from, to));
+            }
+        }
+        if !self.descriptions.is_empty() {
+            lines.push("Operations:".to_string());
+            for desc in &self.descriptions {
+                lines.push(format!("  - {}", desc));
+            }
+        }
+        lines.push(format!("Bytes added: {}", self.bytes_added));
+        lines.push(format!("Bytes removed: {}", self.bytes_removed));
+        lines.join("\n")
+    }
+}
+
+async fn read_file_normalized(path: &str) -> Result<Option<String>, String> {
+    match tokio::fs::read(path).await {
+        Ok(bytes) => {
+            let text = String::from_utf8_lossy(&bytes).to_string();
+            Ok(Some(normalize_newlines(&text)))
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!("Failed to read file {}: {}", path, e)),
+    }
+}
+
+async fn path_exists_on_disk(path: &str) -> Result<bool, String> {
+    match tokio::fs::metadata(path).await {
+        Ok(_) => Ok(true),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(format!("Failed to inspect {}: {}", path, e)),
+    }
+}
+
+fn normalize_newlines(text: &str) -> String {
+    if text.contains('\r') {
+        text.replace("\r\n", "\n").replace('\r', "\n")
+    } else {
+        text.to_string()
+    }
+}
+
+fn exactly_once(haystack: &str, needle: &str) -> Result<usize, String> {
+    let mut matches = haystack.match_indices(needle);
+    let first = matches.next().ok_or_else(|| "anchor not found".to_string())?;
+    if matches.next().is_some() {
+        return Err("anchor ambiguous (found >1)".to_string());
+    }
+    Ok(first.0)
+}

--- a/core/src/tools/registry.rs
+++ b/core/src/tools/registry.rs
@@ -131,10 +131,31 @@ impl ToolRegistry {
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "unified_diff": { "type": "string", "description": "Unified diff to apply" },
-                    "dry_run": { "type": "boolean", "description": "Dry run without applying changes" }
+                    "dry_run": { "type": "boolean", "description": "Dry run without applying changes" },
+                    "ops": {
+                        "type": "array",
+                        "description": "Sequence of filesystem edit operations",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string",
+                                    "enum": ["set_file", "replace_once", "insert_before", "insert_after", "delete_file", "rename_file"]
+                                },
+                                "path": { "type": "string" },
+                                "contents": { "type": "string" },
+                                "find": { "type": "string" },
+                                "replace": { "type": "string" },
+                                "anchor": { "type": "string" },
+                                "insert": { "type": "string" },
+                                "to": { "type": "string" }
+                            },
+                            "required": ["type"],
+                            "additionalProperties": false
+                        }
+                    }
                 },
-                "required": ["unified_diff"]
+                "required": ["ops"]
             }),
             output_schema: json!({
                 "type": "object",

--- a/core/src/tools/tests/registry_tests.rs
+++ b/core/src/tools/tests/registry_tests.rs
@@ -330,8 +330,14 @@ async fn test_tool_registry_comprehensive_validation() {
         (
             ToolName::FsApplyPatch,
             json!({
-                "unified_diff": "--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new",
-                "dry_run": false
+                "dry_run": false,
+                "ops": [
+                    {
+                        "type": "set_file",
+                        "path": "/tmp/example.txt",
+                        "contents": "example"
+                    }
+                ]
             }),
         ),
         (

--- a/core/src/tools/tests/types_tests.rs
+++ b/core/src/tools/tests/types_tests.rs
@@ -131,26 +131,29 @@ fn test_fs_write_result_serialization() {
     assert_eq!(deserialized.bytes_written, result.bytes_written);
 }
 
+
 #[test]
 fn test_fs_apply_patch_args_serialization() {
-    let patch = r#"--- old_file.txt
-+++ new_file.txt
-@@ -1,3 +1,3 @@
- line 1
--old line 2
-+new line 2
- line 3"#;
-    
     let args = FsApplyPatchArgs {
-        unified_diff: patch.to_string(),
         dry_run: true,
+        ops: vec![
+            SimpleEditOp::SetFile {
+                path: "file.txt".to_string(),
+                contents: "hello\n".to_string(),
+            },
+            SimpleEditOp::ReplaceOnce {
+                path: "file.txt".to_string(),
+                find: "hello\n".to_string(),
+                replace: "world\n".to_string(),
+            },
+        ],
     };
-    
+
     let serialized = to_value(&args).unwrap();
     let deserialized: FsApplyPatchArgs = from_value(serialized).unwrap();
-    
-    assert_eq!(deserialized.unified_diff, args.unified_diff);
+
     assert_eq!(deserialized.dry_run, args.dry_run);
+    assert_eq!(deserialized.ops.len(), args.ops.len());
 }
 
 #[test]

--- a/core/src/tools/types.rs
+++ b/core/src/tools/types.rs
@@ -63,9 +63,21 @@ pub struct FsWriteResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SimpleEditOp {
+    SetFile { path: String, contents: String },
+    ReplaceOnce { path: String, find: String, replace: String },
+    InsertBefore { path: String, anchor: String, insert: String },
+    InsertAfter { path: String, anchor: String, insert: String },
+    DeleteFile { path: String },
+    RenameFile { path: String, to: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FsApplyPatchArgs {
-    pub unified_diff: String,
+    #[serde(default)]
     pub dry_run: bool,
+    pub ops: Vec<SimpleEditOp>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tui/src/components/tools.rs
+++ b/tui/src/components/tools.rs
@@ -244,7 +244,18 @@ impl ToolsComponent {
             grok_core::ToolName::FsApplyPatch => {
                 if let Ok(patch_args) = serde_json::from_value::<grok_core::tools::FsApplyPatchArgs>(args.clone()) {
                     all_lines.push(Line::from(Span::styled("Parameters:", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))));
-                    all_lines.push(Line::from(format!("  Diff size: {} characters", patch_args.unified_diff.len())));
+                    all_lines.push(Line::from(format!("  Operations: {}", patch_args.ops.len())));
+                    if !patch_args.ops.is_empty() {
+                        let op_types: Vec<&'static str> = patch_args.ops.iter().map(|op| match op {
+                            grok_core::tools::SimpleEditOp::SetFile { .. } => "set_file",
+                            grok_core::tools::SimpleEditOp::ReplaceOnce { .. } => "replace_once",
+                            grok_core::tools::SimpleEditOp::InsertBefore { .. } => "insert_before",
+                            grok_core::tools::SimpleEditOp::InsertAfter { .. } => "insert_after",
+                            grok_core::tools::SimpleEditOp::DeleteFile { .. } => "delete_file",
+                            grok_core::tools::SimpleEditOp::RenameFile { .. } => "rename_file",
+                        }).collect();
+                        all_lines.push(Line::from(format!("  Op types: {}", op_types.join(", "))));
+                    }
                     if patch_args.dry_run {
                         all_lines.push(Line::from("  Mode: Dry run"));
                     }


### PR DESCRIPTION
## Summary
- add SimpleEditOp definitions and a SimpleEditPlanner that applies operations with newline normalization and fail-fast validation
- update the filesystem executor, registry metadata, tests, TUI display, and documentation to describe the new SimpleEditSpec workflow
- ensure fs executor integration tests use unambiguous anchors for insert operations

## Testing
- `cargo test -p grok-core`


------
https://chatgpt.com/codex/tasks/task_e_68d6eeb1918883278245f7c6097cda63